### PR TITLE
docs(db): Remove tasks table references

### DIFF
--- a/database/diagram.md
+++ b/database/diagram.md
@@ -2,29 +2,27 @@
 
 ```mermaid
 erDiagram
+    users }o--|| roles:                 "Have role"
+    users ||--o{ class_has_users:       "Belong to multiple classes"
+    users ||--o{ submissions:           "Make submissions"
+    users ||--o| grades:                "Have grades"
+
     classes }o--|| users:               "Have teacher"
     classes }o--|| colors:              "Have color"
     classes ||--o{ class_has_users:     "Have students"
     classes ||--o{ laboratories:        "Have laboratories"
 
-    laboratories ||--|{	tasks:          "Have tasks"
-    laboratories ||--o|	rubrics:        "Can have a rubric"
+    laboratories ||--o{ markdown_blocks:    "Have instructions"
+    laboratories ||--o{ test_blocks:        "Have tests"
+    laboratories ||--o|	rubrics:            "Can have a rubric"
+    grades }o--|| laboratories:             "Belong a laboratory"
 
-    tasks ||--o{ markdown_blocks:       "Have instructions"
-    tasks ||--o{ test_blocks:           "Have code steps"
 
     test_blocks  }o--|| languages:      "Have programming language"
-    test_blocks ||--o{ submissions:     "Have submissions"
-
-    users }o--|| roles:                 "Have role"
-    users ||--o| grades:                "Have grades"
-    users ||--o{ submissions:           "Make submissions"
-    users ||--o{ class_has_users:       "Belong to multiple classes"
+    submissions }o--|| test_blocks:    "Belong to a test"
 
     rubrics ||--|{	objectives:         "Have one or more objectives"
     objectives ||--|{ criteria:         "Have one or mor criteria"
-    laboratories ||--o| grades:         "Belong to laboratories"
-
 
 	roles {
         UUID            id          "PK; AUTO"
@@ -69,22 +67,16 @@ erDiagram
         Timestamp           due_date        "NOT NULL"
     }
 
-    tasks {
-        UUID        id              "PK; AUTO"
-        UUID        laboratory_id   "FK; REFERENCES laboratories.id"
-        Timestamp   created_at      "DEFAULT NOW"
-    }
-
     markdown_blocks {
         UUID            id              "PK; AUTO"
-        UUID            task_id         "FK; REFERENCES tasks.id"
+        UUID            laboratory_id   "FK; REFERENCES laboratories.id"
         VARCHAR()       content         "NULL"
         Uint            index           "NOT NULL; DEFAULT 0"
     }
 
     test_blocks {
         UUID            id              "PK; AUTO"
-        UUID            task_id         "FK; REFERENCES tasks.id"
+        UUID            laboratory_id   "FK; REFERENCES laboratories.id"
         UUID            language        "FK; REFERENCES languages.uuid"
         VARCHAR(255)    name            "NOT NULL"
         BLOB            tests_archive   "NOT NULL"
@@ -137,7 +129,7 @@ erDiagram
 
 ## Design notes 🤔
 
-- `Laboratories` are made up of `tasks` which are made up of `markdown blocks` and `test blocks`.
+- `Laboratories` are made up of `markdown blocks` to provide instructions to the students and `test blocks` to test the code written by the students.
 
 - The `markdown blocks` are used by teachers to provide instructions to the students.
 

--- a/database/queries.md
+++ b/database/queries.md
@@ -31,7 +31,7 @@ END $$
 
 ### Get the students enrolled in a class
 
-````sql
+```sql
 CREATE OR REPLACE FUNCTION get_students_enrolled_in_class(
     class_id UUID
 )
@@ -53,12 +53,12 @@ BEGIN
         class_has_users.class_id = class_id AND
         class_has_users.is_user_active = TRUE;
 END $$
+;
+```
 
 ## Laboratories 🧪
 
 ### Create a new laboratory
-
-Creating a new laboratory also creates a default or first tasks to allow the teachers to start writing instructions and tests.
 
 ```sql
 CREATE OR REPLACE FUNCTION create_laboratory(
@@ -72,22 +72,15 @@ CREATE OR REPLACE FUNCTION create_laboratory(
     AS $$
 DECLARE
     laboratory_id UUID;
-    first_task_id UUID;
-    result RECORD;
 BEGIN
     INSERT INTO laboratories (class_id, name, opening_date, due_date)
     VALUES (class_id, name, opening_date, due_date)
     RETURNING id INTO laboratory_id;
 
-    INSERT INTO tasks (laboratory_id)
-    VALUES (laboratory_id)
-    RETURNING id INTO first_task_id;
-
-    result := (laboratory_id, first_task_id);
-    RETURN result;
+    RETURN laboratory_id;
 END $$
 ;
-````
+```
 
 ### Swap the position of two blocks
 
@@ -152,11 +145,10 @@ DECLARE
 BEGIN
     -- Get the number of tests
     SELECT COUNT(*) INTO tests_count FROM test_blocks
-    WHERE task_id IN (
-        SELECT id FROM tasks
-        WHERE laboratory_id = laboratory_id_param
-    );
+    WHERE
+        laboratory_id = laboratory_id_param;
 
     RETURN tests_count;
 END $$
+;
 ```

--- a/database/views.md
+++ b/database/views.md
@@ -23,8 +23,7 @@ CREATE OR REPLACE VIEW students_advances_view AS
         COUNT(submissions.id)   AS passing_tests
     FROM submissions
     JOIN test_blocks ON submissions.test_id = test_blocks.id
-    JOIN tasks ON test_blocks.task_id = tasks.id
-    JOIN laboratories ON tasks.laboratory_id = laboratories.id
+    JOIN laboratories ON test_blocks.laboratory_id = laboratories.id
     WHERE submissions.passing = TRUE
     GROUP BY submissions.test_id, submissions.student_id;
 ```


### PR DESCRIPTION
## Includes 📋

- Remove `tasks` table from the database diagram and update foreign keys. 
- Update queries referencing the old `tasks` table.
- Update view to remove references to the `tasks` table.

## Related Issues 🔎

Closes #8 
